### PR TITLE
feat: save raw HTML so that we could start over if there is a problem with the parsing

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -1,0 +1,20 @@
+name: dry-run
+
+on: pull_request
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+          cache: "npm"
+      - run: npm ci
+      - run: npm --workspace=collector run start $(pwd)/archive/raw/$(date +'%Y-%m-%d')
+      - run: git status
+      - uses: actions/upload-artifact@v2
+        with:
+          name: screenshots
+          path: "packages/collector/*.png"

--- a/packages/collector/package-lock.json
+++ b/packages/collector/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "collector",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {

--- a/packages/collector/src/main.ts
+++ b/packages/collector/src/main.ts
@@ -41,10 +41,8 @@ function getToday() {
 }
 
 async function exportHTML(slug: string, content: string) {
-  await fs.writeFile(
-    path.join(process.argv[2].replace("/raw/", "/html/"), `${slug}.html`),
-    content
-  );
+  await fs.mkdir(HTML_PATH, { recursive: true });
+  await fs.writeFile(path.join(HTML_PATH, `${slug}.html`), content);
 }
 async function exportTo(
   result: { slug: string; items: Record<string, any>[] }[],

--- a/packages/collector/src/pageObjects/TrendingPage.ts
+++ b/packages/collector/src/pageObjects/TrendingPage.ts
@@ -25,7 +25,7 @@ export class TrendingPage {
     url = ENDPOINT,
     retry = 0
   ): Promise<TrendingPage> {
-    await page.goto(url, { waitUntil: "domcontentloaded" });
+    await page.goto(url, { waitUntil: "networkidle0" });
     try {
       await page.waitForSelector("article", { timeout: 5000 });
     } catch {
@@ -46,6 +46,12 @@ export class TrendingPage {
     return new TrendingPage(page);
   }
 
+  static async fromHTML(page: Page, html: string): Promise<TrendingPage> {
+    await page.goto("about:blank");
+    await page.setContent(html);
+    return new TrendingPage(page);
+  }
+
   async getLanguages(): Promise<Language[]> {
     return this.page
       .$$eval('#languages-menuitems [role="menuitemradio"]', (elements) =>
@@ -60,6 +66,10 @@ export class TrendingPage {
         })
       )
       .then((ret) => [{ url: ENDPOINT, label: "", slug: "" }].concat(ret));
+  }
+
+  async getOuterHTML(): Promise<string> {
+    return this.page.$eval("body", (body) => body.outerHTML);
   }
 
   async getRepositories(): Promise<Repository[]> {


### PR DESCRIPTION
For example, if we have raw HTML, https://github.com/Leko/github-trending-archive/pull/3 could be applied for all periods since the start of the tally.

- Prev: Fetch the page with puppeteer and parse the page content
- Current: Fetch the HTML with puppeteer and save it as a file, then parse the HTML string with puppeteer